### PR TITLE
Windows, at the very least, doesn't allow for colons in filenames. …

### DIFF
--- a/script/utils.py
+++ b/script/utils.py
@@ -53,6 +53,7 @@ def download_file(r, url, directory, filename):
         os.makedirs(directory)
         log_info('[+] created new directory: ' + directory)
 
+    filename = filename.replace(':', '-')
     path = os.path.join(directory, filename)
 
     print '[-] downloading file from url: {0}'.format(url)


### PR DESCRIPTION
…*nix requires they be escaped at a minimum, I believe. Let's just not allow them.

Came up while trying to download today's book.