### PR TITLE
Adding support of Google Drive folder

### DIFF
--- a/config/prod_example.cfg
+++ b/config/prod_example.cfg
@@ -21,6 +21,7 @@ drive.oauth2_scope=https://www.googleapis.com/auth/drive
 drive.client_secrets=config/client_secrets.json
 drive.auth_token=config/auth_token.json
 drive.gmail=GOOGLE_DRIVE@gmail.com
+drive.default_folder=packtpub
 
 [notify]
 notify.host=smtp.gmail.com


### PR DESCRIPTION
The script now supports Google Drive folder!
It will create a folder with name "packtpub" or specified in the config file.
The folder is also set to be shared.
The config line is printed on the screen to prompt user to add it back into the config file.
All the files are then uploaded to this folder.

a minor fix of message