### PR TITLE
Update utils.py

### DIFF
--- a/script/utils.py
+++ b/script/utils.py
@@ -59,8 +59,12 @@ def download_file(r, url, directory, filename, headers):
     print '[-] downloading file from url: {0}'.format(url)
     response = r.get(url, headers=headers, stream=True)
     #log_dict(response.headers)
+    total_length = 0
+    test_length = response.headers.get('content-length')
+    if test_length is not None:
+        total_length = int(test_length)    
+
     with open(path, 'wb') as f:
-        total_length = int(response.headers.get('content-length'))
         for chunk in progress.bar(response.iter_content(chunk_size=1024), expected_size=(total_length/1024) + 1):
             if chunk:
                 f.write(chunk)


### PR DESCRIPTION
some files have no 'content-length' i'm from France, CDN trouble ?
i have read the doc 'content-length' if not present response.headers.get('content-length') return None type
so we have to test before doing int()
the download function works well if total_length = 0, but whit a weird progress but it's ok

i have tested in the 2 cases