### PR TITLE
Download books and extras into separate directories

### DIFF
--- a/config/dev.cfg
+++ b/config/dev.cfg
@@ -16,7 +16,8 @@ credential.password=testPwd
 
 [path]
 path.ebooks=ebooks
-path.extras=ebooks/extras
+path.extras=extras
+path.separate=true
 
 [drive]
 drive.oauth2_scope=https://www.googleapis.com/auth/drive

--- a/config/dev.cfg
+++ b/config/dev.cfg
@@ -16,8 +16,9 @@ credential.password=testPwd
 
 [path]
 path.ebooks=ebooks
-path.extras=extras
-path.separate=true
+path.extras=ebooks/extras
+#path.separate.ebooks=MY/EBOOKS/FOLDER
+#path.separate.extras=MY/EXTRAS/FOLDER
 
 [drive]
 drive.oauth2_scope=https://www.googleapis.com/auth/drive

--- a/config/prod_example.cfg
+++ b/config/prod_example.cfg
@@ -14,7 +14,8 @@ credential.password=PACKTPUB_PASSWORD
 
 [path]
 path.ebooks=ebooks
-path.extras=ebooks/extras
+path.extras=extras
+path.separate=true
 
 [drive]
 drive.oauth2_scope=https://www.googleapis.com/auth/drive

--- a/config/prod_example.cfg
+++ b/config/prod_example.cfg
@@ -17,6 +17,7 @@ path.ebooks=ebooks
 path.extras=ebooks/extras
 #path.separate.ebooks=MY/EBOOKS/FOLDER
 #path.separate.extras=MY/EXTRAS/FOLDER
+path.separate.space=_
 
 [drive]
 drive.oauth2_scope=https://www.googleapis.com/auth/drive

--- a/config/prod_example.cfg
+++ b/config/prod_example.cfg
@@ -14,8 +14,9 @@ credential.password=PACKTPUB_PASSWORD
 
 [path]
 path.ebooks=ebooks
-path.extras=extras
-path.separate=true
+path.extras=ebooks/extras
+#path.separate.ebooks=MY/EBOOKS/FOLDER
+#path.separate.extras=MY/EXTRAS/FOLDER
 
 [drive]
 drive.oauth2_scope=https://www.googleapis.com/auth/drive

--- a/script/packtpub.py
+++ b/script/packtpub.py
@@ -124,7 +124,12 @@ class Packpub(object):
             for type in types]
 
         if self.__config.has_option('path', 'path.separate.extras'):
-            directory = self.__config.get('path', 'path.separate.ebooks') + '/' + self.info['title'] + ' - ' + self.info['author']
+            space = self.__config.get('path', 'path.separate.space')
+
+            if space == '?':
+                space = ' '
+
+            directory = self.__config.get('path', 'path.separate.ebooks') + '/' + self.info['title'].encode('ascii', 'ignore').replace(' ', space) + space + '-' + space + self.info['author'].encode('ascii', 'ignore').replace(' ', space)
         else:
             directory = self.__config.get('path', 'path.ebooks')
 
@@ -137,7 +142,12 @@ class Packpub(object):
         """
 
         if self.__config.has_option('path', 'path.separate.extras'):
-            directory = self.__config.get('path', 'path.separate.ebooks') + '/' + self.info['title'] + ' - ' + self.info['author'] + '/' +  self.__config.get('path', 'path.separate.extras')
+            space = self.__config.get('path', 'path.separate.space')
+
+            if space == '?':
+                space = ' '
+
+            directory = self.__config.get('path', 'path.separate.ebooks') + '/' + self.info['title'].encode('ascii', 'ignore').replace(' ', space) + space + '-' + space + self.info['author'].encode('ascii', 'ignore').replace(' ', space) + '/' +  self.__config.get('path', 'path.separate.extras')
         else:
             directory = self.__config.get('path', 'path.extras')
 

--- a/script/packtpub.py
+++ b/script/packtpub.py
@@ -124,6 +124,10 @@ class Packpub(object):
             for type in types]
 
         directory = self.__config.get('path', 'path.ebooks')
+
+        if self.__config.get('path', 'path.separate') == "true":
+            directory = directory + '/' + self.info['title'] + ' - ' + self.info['author']
+
         for download in downloads_info:
             self.info['paths'].append(
                 download_file(self.__session, download['url'], directory, download['filename'], self.__headers))
@@ -133,6 +137,9 @@ class Packpub(object):
         """
 
         directory = self.__config.get('path', 'path.extras')
+
+        if self.__config.get('path', 'path.separate') == "true":
+            directory = self.__config.get('path', 'path.ebooks') + '/' + self.info['title'] + ' - ' + self.info['author'] + '/' +  directory
 
         url_image = self.info['url_image']
         filename = self.info['filename'] + '_' + split(url_image)[1]

--- a/script/packtpub.py
+++ b/script/packtpub.py
@@ -123,10 +123,10 @@ class Packpub(object):
             filename=self.info['filename'] + '.' + type)
             for type in types]
 
-        directory = self.__config.get('path', 'path.ebooks')
-
-        if self.__config.get('path', 'path.separate') == "true":
-            directory = directory + '/' + self.info['title'] + ' - ' + self.info['author']
+        if self.__config.has_option('path', 'path.separate.extras'):
+            directory = self.__config.get('path', 'path.separate.ebooks') + '/' + self.info['title'] + ' - ' + self.info['author']
+        else:
+            directory = self.__config.get('path', 'path.ebooks')
 
         for download in downloads_info:
             self.info['paths'].append(
@@ -136,10 +136,10 @@ class Packpub(object):
         """
         """
 
-        directory = self.__config.get('path', 'path.extras')
-
-        if self.__config.get('path', 'path.separate') == "true":
-            directory = self.__config.get('path', 'path.ebooks') + '/' + self.info['title'] + ' - ' + self.info['author'] + '/' +  directory
+        if self.__config.has_option('path', 'path.separate.extras'):
+            directory = self.__config.get('path', 'path.separate.ebooks') + '/' + self.info['title'] + ' - ' + self.info['author'] + '/' +  self.__config.get('path', 'path.separate.extras')
+        else:
+            directory = self.__config.get('path', 'path.extras')
 
         url_image = self.info['url_image']
         filename = self.info['filename'] + '_' + split(url_image)[1]


### PR DESCRIPTION
### Short description
If ``path.separate`` is set to ``true`` in the configuration file, downloads books and extras into separate directories.

### Examples
If ``path.separate`` is set to ``true``, ``path.ebooks=ebooks`` and ``path.extras=extras``, ebooks and extras are downloaded to the following locations:
``
ebooks/TITLE - AUTHOR/TITLE.pdf
``
``
ebooks/TITLE - AUTHOR/extras/TITLE.png
``

Note that if you use separate directories, ``path.extras`` behaves differently:

If ``path.separate`` is set to ``false``, ``path.ebooks=ebooks`` and ``path.extras=ebooks/extras``, ebooks and extras are downloaded to the following locations:
``
ebooks/TITLE.pdf
``
``
ebooks/extras/TITLE.png
``

### Disclaimer
The code is only a suggestion (preview) of new functionality, but works properly with local downloads. Other features to check (possible complications with Google Drive upload). Instead of setting this in the configuration file, separate or not directory can be changed by additional option from the command line.