### PR TITLE
Allow claiming only

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ python script/spider.py --config config/prod.cfg --all --extras --upload drive
 
 # download and notify: gmail|ifttt|join
 python script/spider.py -c config/prod.cfg --notify gmail
+
+# only claim book (no downloads):
+python script/spider.py -c config/prod.cfg --notify gmail --claimOnly
 ```
 
 ### Basic setup

--- a/script/packtpub.py
+++ b/script/packtpub.py
@@ -44,7 +44,7 @@ class Packpub(object):
             url += self.__config.get('url', 'url.login')
 
         response = self.__session.get(url, headers=self.__headers)
-        self.__log_response(response)
+        self.__log_response(response, 'GET', self.__dev)
 
         soup = make_soup(response)
         form = soup.find('form', {'id': 'packt-user-login-form'})
@@ -63,11 +63,11 @@ class Packpub(object):
         if self.__dev:
             url += self.__config.get('url', 'url.loginPost')
             response = self.__session.get(url, headers=self.__headers, data=data)
-            self.__log_response(response)
+            self.__log_response(response, 'GET', self.__dev)
         else:
             url += self.__config.get('url', 'url.login')
             response = self.__session.post(url, headers=self.__headers, data=data)
-            self.__log_response(response, 'POST', True)
+            self.__log_response(response, 'POST', self.__dev)
 
         soup = make_soup(response)
         div_target = soup.find('div', {'id': 'deal-of-the-day'})
@@ -89,7 +89,7 @@ class Packpub(object):
             url = self.info['url_claim']
 
         response = self.__session.get(url, headers=self.__headers)
-        self.__log_response(response)
+        self.__log_response(response, 'GET', self.__dev)
 
         soup = make_soup(response)
         div_target = soup.find('div', {'id': 'product-account-list'})

--- a/script/utils.py
+++ b/script/utils.py
@@ -23,7 +23,7 @@ def config_file(path):
     if not os.path.exists(path):
         raise IOError('file not found!')
 
-    log_info('[+] configuration file: {0}'.format(path))
+    log_info('[*] configuration file: {0}'.format(path))
     config = ConfigParser.ConfigParser()
     config.read(path)
     return config
@@ -62,7 +62,7 @@ def download_file(r, url, directory, filename, headers):
     total_length = 0
     test_length = response.headers.get('content-length')
     if test_length is not None:
-        total_length = int(test_length)    
+        total_length = int(test_length)
 
     with open(path, 'wb') as f:
         for chunk in progress.bar(response.iter_content(chunk_size=1024), expected_size=(total_length/1024) + 1):


### PR DESCRIPTION
I'm running the script on a server with only little storage and I don't need most of the books asap. With the --claimOnly flag the script only claims the book (duh) and sends out notifications. This way it can even run on raspberry pis, your phone, etc.

I also messed around with the logging so that it only prints details on dev. Hope that's ok.

Cheers! 