### PR TITLE
Check if URL is from packtpub

### DIFF
--- a/script/spider.py
+++ b/script/spider.py
@@ -115,7 +115,7 @@ def main():
 
         if currentNewsletterUrl == '':
             log_info('[*] no free eBook from newsletter right now')
-        elif not currentNewsletterUrl.startswith('http'):
+        elif not currentNewsletterUrl.startswith('https://www.packtpub.com'):
             log_warn('[-] invalid URL from newsletter: ' + currentNewsletterUrl)
         elif lastNewsletterUrl != currentNewsletterUrl:
             log_info('[*] getting free eBook from newsletter')


### PR DESCRIPTION
If someone (maybe in a fork) creates a page with the same DOM as packtpub and supplies a newsletter URL that points there, he could make the script download malicious or spammy PDFs without the users knowledge. So it's better to check if the provided URL actually points to packtpub.