### PR TITLE
Check if newsletter was already claimed before processing

### DIFF
--- a/script/alreadyClaimedException.py
+++ b/script/alreadyClaimedException.py
@@ -1,0 +1,2 @@
+class AlreadyClaimedException(Exception):
+    pass

--- a/script/noBookException.py
+++ b/script/noBookException.py
@@ -1,2 +1,0 @@
-class NoBookException(Exception):
-    pass

--- a/script/packtpub.py
+++ b/script/packtpub.py
@@ -4,6 +4,7 @@ from os.path import split, join
 from utils import make_soup, wait, download_file
 from logs import *
 from noBookException import NoBookException
+from alreadyClaimedException import AlreadyClaimedException
 
 class Packtpub(object):
     """
@@ -16,6 +17,9 @@ class Packtpub(object):
         self.__url_base = self.__config.get('url', 'url.base')
         self.__headers = self.__init_headers()
         self.__session = requests.Session()
+        self.resetInfo()
+
+    def resetInfo(self):
         self.info = {
             'paths': []
         }
@@ -121,6 +125,11 @@ class Packtpub(object):
 
         if div_target is None:
             raise Exception('Could not access claim page. This is most likely caused by invalid credentials')
+
+        errorMessage = soup.find(id='messages-container')
+
+        if errorMessage is not None and errorMessage.text.strip() == 'You have already claimed this promotion.':
+            raise AlreadyClaimedException()
 
         # only last one just claimed
         div_claimed_book = div_target.select('.product-line')[0]

--- a/script/spider.py
+++ b/script/spider.py
@@ -11,6 +11,7 @@ from database import Database, DB_FIREBASE
 from logs import *
 from notify import Notify, SERVICE_GMAIL, SERVICE_IFTTT, SERVICE_JOIN
 from noBookException import NoBookException
+from alreadyClaimedException import AlreadyClaimedException
 
 def parse_types(args):
     if args.types is None:
@@ -120,12 +121,17 @@ def main():
         elif lastNewsletterUrl != currentNewsletterUrl:
             log_info('[*] getting free eBook from newsletter')
             try:
+                packtpub.resetInfo()
                 packtpub.runNewsletter(currentNewsletterUrl)
                 handleClaim(packtpub, args, config, dir_path)
 
                 with open(lastNewsletterUrlPath, 'w+') as f:
                     f.write(currentNewsletterUrl)
 
+            except AlreadyClaimedException as a:
+                log_info('[*] book was already claimed, skipping')
+                with open(lastNewsletterUrlPath, 'w+') as f:
+                    f.write(currentNewsletterUrl)
             except Exception as e:
                 log_debug(e)
                 if args.notify:


### PR DESCRIPTION
If the lastNewsletterUrl fiel got deleted and a new daily book was already released, the script wronly parses the first entry in the archive as the newsletter book, thus overwriting the data of the current daily one