### PR TITLE
only prepend dir_path when folder path ist not absolute

### DIFF
--- a/script/packtpub.py
+++ b/script/packtpub.py
@@ -171,7 +171,7 @@ class Packtpub(object):
         self.__GET_claim()
         wait(self.__delay, self.__dev)
 
-    def download_ebooks(self, types, base_path):
+    def download_ebooks(self, types):
         """
         """
         downloads_info = [dict(type=type,
@@ -185,15 +185,15 @@ class Packtpub(object):
             folder_name = self.info['title'].encode('ascii', 'ignore').replace(' ', '_') + \
                           self.info['author'].encode('ascii', 'ignore').replace(' ', '_')
 
-            directory = base_path + join(self.__config.get('path', 'path.ebooks'), folder_name)
+            directory = join(self.__config.get('path', 'path.ebooks'), folder_name)
         else:
-            directory = base_path + self.__config.get('path', 'path.ebooks')
+            directory = self.__config.get('path', 'path.ebooks')
 
         for download in downloads_info:
             self.info['paths'].append(
                 download_file(self.__session, download['url'], directory, download['filename'], self.__headers))
 
-    def download_extras(self, base_path):
+    def download_extras(self):
         """
         """
 
@@ -203,9 +203,9 @@ class Packtpub(object):
             folder_name = self.info['title'].encode('ascii', 'ignore').replace(' ', '_') + \
                           self.info['author'].encode('ascii', 'ignore').replace(' ', '_')
 
-            directory = base_path + join(self.__config.get('path', 'path.ebooks'), folder_name, self.__config.get('path', 'path.extras'))
+            directory = join(self.__config.get('path', 'path.ebooks'), folder_name, self.__config.get('path', 'path.extras'))
         else:
-            directory = base_path + self.__config.get('path', 'path.extras')
+            directory = self.__config.get('path', 'path.extras')
 
         url_image = self.info['url_image']
         filename = self.info['filename'] + '_' + split(url_image)[1]

--- a/script/spider.py
+++ b/script/spider.py
@@ -4,6 +4,7 @@ import argparse
 import datetime
 import requests
 import os
+import sys
 from utils import ip_address, config_file
 from packtpub import Packtpub
 from upload import Upload, SERVICE_GOOGLE_DRIVE, SERVICE_ONEDRIVE, SERVICE_DROPBOX, SERVICE_SCP
@@ -31,10 +32,10 @@ def handleClaim(packtpub, args, config, dir_path):
     if not args.claimOnly:
         types = parse_types(args)
 
-        packtpub.download_ebooks(types, dir_path)
+        packtpub.download_ebooks(types)
 
         if args.extras:
-            packtpub.download_extras(dir_path)
+            packtpub.download_extras()
 
         if args.archive:
             raise NotImplementedError('not implemented yet!')
@@ -93,9 +94,14 @@ def main():
         #ip_address()
         log_info('[*] getting daily free eBook')
 
+        downloadPath = config.get('path', 'path.ebooks')
+
+        if not dir_path.startswith('/'):
+            downloadPath = dir_path + downloadPath
+
         try:
             packtpub.runDaily()
-            handleClaim(packtpub, args, config, dir_path)
+            handleClaim(packtpub, args, config, downloadPath)
         except NoBookException as e:
             log_info('[*] ' + e.message)
         except Exception as e:
@@ -123,7 +129,7 @@ def main():
             try:
                 packtpub.resetInfo()
                 packtpub.runNewsletter(currentNewsletterUrl)
-                handleClaim(packtpub, args, config, dir_path)
+                handleClaim(packtpub, args, config, downloadPath)
 
                 with open(lastNewsletterUrlPath, 'w+') as f:
                     f.write(currentNewsletterUrl)


### PR DESCRIPTION
Absolute paths for download folders "path.ebooks=/home/user/library/ebooks" will now work so that they are not forced to be in the packtpub folder.

Since paths starting with a slash would have broken the script ("/ebooks" -> "packtpub//ebooks"), this should not break any configurations.